### PR TITLE
ConformanceTest - Less messy output

### DIFF
--- a/tests/phpunit/Civi/API/V4/ConformanceTest.php
+++ b/tests/phpunit/Civi/API/V4/ConformanceTest.php
@@ -10,6 +10,9 @@ use Civi\Test\TransactionalInterface;
 /**
  * @group headless
  *
+ * Tip: If you are focusing on development/debugging of this test, you
+ * can set an environment variable `API4_DEBUG=1`.
+ *
  * This uses some hook kernel set-up copied from
  *   tests/phpunit/CiviTest/CiviUnitTestCase.php
  */
@@ -41,7 +44,9 @@ class ConformanceTest extends UnitTestCase {
    * @param string $string to report
    */
   protected function report($string) {
-    echo $string . "\n";
+    if (getenv('API4_DEBUG')) {
+      echo $string . "\n";
+    }
   }
 
   /**


### PR DESCRIPTION
This test seems to include some debug output.  I can understand if you guys
want that noisy/debug mode to be available, but for a default run of the test
suite we should just use phpunit's normal output.

This patch is a compromise -- if you want the debug output, then set an
environment variable `API4_DEBUG=1`.