### PR TITLE
Fix Joins On Reverse 1-to-n Select

### DIFF
--- a/Civi/Api4/Event/Events.php
+++ b/Civi/Api4/Event/Events.php
@@ -17,4 +17,9 @@ class Events {
    */
   const SCHEMA_MAP_BUILD = 'api.schema_map.build';
 
+  /**
+   * Alter query results of APIv4 select query
+   */
+  const POST_SELECT_QUERY = 'api.select_query.post';
+
 }

--- a/Civi/Api4/Event/PostSelectQueryEvent.php
+++ b/Civi/Api4/Event/PostSelectQueryEvent.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Civi\Api4\Event;
+
+use Civi\Api4\Query\Api4SelectQuery;
+use Symfony\Component\EventDispatcher\Event;
+
+class PostSelectQueryEvent extends Event {
+
+  /**
+   * @var array
+   */
+  protected $results;
+
+  /**
+   * @var Api4SelectQuery
+   */
+  protected $query;
+
+  /**
+   * PostSelectQueryEvent constructor.
+   * @param array $results
+   * @param Api4SelectQuery $query
+   */
+  public function __construct(array $results, Api4SelectQuery $query) {
+    $this->results = $results;
+    $this->query = $query;
+  }
+
+  /**
+   * @return array
+   */
+  public function getResults() {
+    return $this->results;
+  }
+
+  /**
+   * @param array $results
+   * @return $this
+   */
+  public function setResults($results) {
+    $this->results = $results;
+
+    return $this;
+  }
+
+  /**
+   * @return Api4SelectQuery
+   */
+  public function getQuery() {
+    return $this->query;
+  }
+
+  /**
+   * @param Api4SelectQuery $query
+   * @return $this
+   */
+  public function setQuery($query) {
+    $this->query = $query;
+
+    return $this;
+  }
+
+}

--- a/Civi/Api4/Event/Subscriber/ContactSchemaMapSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/ContactSchemaMapSubscriber.php
@@ -5,6 +5,8 @@ namespace Civi\Api4\Event\Subscriber;
 use Civi\Api4\Event\Events;
 use Civi\Api4\Event\SchemaMapBuildEvent;
 use Civi\Api4\Service\Schema\Joinable\Joinable;
+use Civi\Api4\Service\Schema\Joinable\OptionValueJoinable;
+use Civi\Api4\Service\Schema\Table;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ContactSchemaMapSubscriber implements EventSubscriberInterface {
@@ -23,10 +25,35 @@ class ContactSchemaMapSubscriber implements EventSubscriberInterface {
   public function onSchemaBuild(SchemaMapBuildEvent $event) {
     $schema = $event->getSchemaMap();
     $table = $schema->getTableByName('civicrm_contact');
-    $joinable = new Joinable('civicrm_activity_contact', 'contact_id', 'created_activities');
-    $joinable->addCondition('created_activities.record_type_id = 1');
+    $this->addCreatedActivitiesLink($table);
+    $this->fixPreferredLanguageLink($table);
+  }
+
+  /**
+   * @param Table $table
+   */
+  private function addCreatedActivitiesLink($table) {
+    $alias = 'created_activities';
+    $joinable = new Joinable('civicrm_activity_contact', 'contact_id', $alias);
+    $joinable->addCondition($alias . '.record_type_id = 1');
     $joinable->setJoinType($joinable::JOIN_TYPE_ONE_TO_MANY);
     $table->addTableLink('id', $joinable);
+  }
+
+  /**
+   * @param Table $table
+   */
+  private function fixPreferredLanguageLink($table) {
+    foreach ($table->getExternalLinks() as $link) {
+      if ($link->getAlias() === 'languages') {
+        $column = 'preferred_language';
+        // language joins on name instead of value (just for fun)
+        $replacement = new OptionValueJoinable('languages', $column, 'name');
+        $table->removeLink($link);
+        $table->addTableLink($column, $replacement);
+        return;
+      }
+    }
   }
 
 }

--- a/Civi/Api4/Event/Subscriber/ContactSchemaMapSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/ContactSchemaMapSubscriber.php
@@ -5,7 +5,6 @@ namespace Civi\Api4\Event\Subscriber;
 use Civi\Api4\Event\Events;
 use Civi\Api4\Event\SchemaMapBuildEvent;
 use Civi\Api4\Service\Schema\Joinable\Joinable;
-use Civi\Api4\Service\Schema\Joinable\OptionValueJoinable;
 use Civi\Api4\Service\Schema\Table;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -26,7 +25,7 @@ class ContactSchemaMapSubscriber implements EventSubscriberInterface {
     $schema = $event->getSchemaMap();
     $table = $schema->getTableByName('civicrm_contact');
     $this->addCreatedActivitiesLink($table);
-    $this->fixPreferredLanguageLink($table);
+    $this->fixPreferredLanguageAlias($table);
   }
 
   /**
@@ -43,14 +42,10 @@ class ContactSchemaMapSubscriber implements EventSubscriberInterface {
   /**
    * @param Table $table
    */
-  private function fixPreferredLanguageLink($table) {
+  private function fixPreferredLanguageAlias($table) {
     foreach ($table->getExternalLinks() as $link) {
       if ($link->getAlias() === 'languages') {
-        $column = 'preferred_language';
-        // language joins on name instead of value (just for fun)
-        $replacement = new OptionValueJoinable('languages', $column, 'name');
-        $table->removeLink($link);
-        $table->addTableLink($column, $replacement);
+        $link->setAlias('preferred_language');
         return;
       }
     }

--- a/Civi/Api4/Event/Subscriber/PostSelectQuerySubscriber.php
+++ b/Civi/Api4/Event/Subscriber/PostSelectQuerySubscriber.php
@@ -1,0 +1,352 @@
+<?php
+
+namespace Civi\Api4\Event\Subscriber;
+
+use Civi\Api4\Event\Events;
+use Civi\Api4\Event\PostSelectQueryEvent;
+use Civi\Api4\Query\Api4SelectQuery;
+use Civi\Api4\Service\Schema\Joinable\Joinable;
+use Civi\Api4\Utils\ArrayInsertionUtil;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Changes the results of a select query, doing 1-n joins and unserializing data
+ */
+class PostSelectQuerySubscriber implements EventSubscriberInterface {
+
+  /**
+   * @inheritdoc
+   */
+  public static function getSubscribedEvents() {
+    return [
+      Events::POST_SELECT_QUERY => 'onPostQuery'
+    ];
+  }
+
+  /**
+   * @param PostSelectQueryEvent $event
+   */
+  public function onPostQuery(PostSelectQueryEvent $event) {
+    $results = $event->getResults();
+    $event->setResults($this->postRun($results, $event->getQuery()));
+  }
+
+  /**
+   * @param array $results
+   * @param Api4SelectQuery $query
+   *
+   * @return array
+   */
+  protected function postRun(array $results, Api4SelectQuery $query) {
+    if (empty($results)) {
+      return $results;
+    }
+
+    $fieldSpec = $query->getApiFieldSpec();
+    $this->unserializeFields($results, $query->getEntity(), $fieldSpec);
+
+    // Group the selects to avoid queries for each field
+    $groupedSelects = $this->getJoinedDotSelects($query);
+    foreach ($groupedSelects as $finalAlias => $selects) {
+      $joinPath = $this->getJoinPathInfo($selects[0], $query);
+      $selects = $this->formatSelects($finalAlias, $selects, $query);
+      $joinResults = $this->getJoinResults($query, $finalAlias, $selects);
+
+      // todo: call formatResults to unserialize joinResults
+      // Insert join results into original result
+      foreach ($results as &$primaryResult) {
+        $baseId = $primaryResult['id'];
+        $filtered = array_filter($joinResults, function ($res) use ($baseId) {
+          return ($res['_base_id'] === $baseId);
+        });
+        $filtered = array_values($filtered);
+        ArrayInsertionUtil::insert($primaryResult, $joinPath, $filtered);
+      }
+    }
+
+    return array_values($results);
+  }
+
+  /**
+   * Unserialize values
+   *
+   * @param array $results
+   * @param string $entity
+   * @param array $fields
+   */
+  protected function unserializeFields(&$results, $entity, $fields = []) {
+    if (empty($fields)) {
+      $params = ['action' => 'get', 'includeCustom' => FALSE];
+      $fields = civicrm_api4($entity, 'getFields', $params)->indexBy('name');
+    }
+
+    foreach ($results as &$result) {
+      foreach ($result as $field => &$value) {
+        if (!empty($fields[$field]['serialize']) && is_string($value)) {
+          $serializationType = $fields[$field]['serialize'];
+          $value = \CRM_Core_DAO::unSerializeField($value, $serializationType);
+        }
+      }
+    }
+  }
+
+  /**
+   * @param Api4SelectQuery $query
+   *
+   * @return array
+   */
+  private function getJoinedDotSelects(Api4SelectQuery $query) {
+    // Remove selects that are not in a joined table
+    $fkAliases = $query->getFkSelectAliases();
+    $joinedDotSelects = array_filter(
+      $query->getSelect(),
+      function ($select) use ($fkAliases) {
+        return isset($fkAliases[$select]);
+      }
+    );
+
+    $selects = [];
+    // group related selects by alias so they can be executed in one query
+    foreach ($joinedDotSelects as $select) {
+      $parts = explode('.', $select);
+      $finalAlias = $parts[count($parts) - 2];
+      $selects[$finalAlias][] = $select;
+    }
+
+    // sort by depth, e.g. email selects should be done before email.location
+    uasort($selects, function ($a, $b) {
+      $aFirst = $a[0];
+      $bFirst = $b[0];
+      return substr_count($aFirst, '.') > substr_count($bFirst, '.');
+    });
+
+    return $selects;
+  }
+
+
+  /**
+   * @param array $selects
+   * @param $serializationType
+   * @param Api4SelectQuery $query
+   *
+   * @return array
+   */
+  private function getResultsForSerializedField(
+    array $selects,
+    $serializationType,
+    Api4SelectQuery $query
+  ) {
+    // Get the alias (Selects are grouped and all target the same table)
+    $sampleField = current($selects);
+    $alias = strstr($sampleField, '.', TRUE);
+
+    // Fetch the results with the serialized field
+    $selects['serialized'] = $query::MAIN_TABLE_ALIAS . '.' . $alias;
+    $serializedResults = $this->runWithNewSelects($selects, $query);
+    $newResults = [];
+
+    // Create a new results array, with a separate entry for each option value
+    foreach ($serializedResults as $result) {
+      $optionValues = \CRM_Core_DAO::unSerializeField(
+        $result['serialized'],
+        $serializationType
+      );
+      unset($result['serialized']);
+      foreach ($optionValues as $value) {
+        $newResults[] = array_merge($result, ['value' => $value]);
+      }
+    }
+
+    $optionValueValues = array_unique(array_column($newResults, 'value'));
+    $optionValues = $this->getOptionValuesFromValues(
+      $selects,
+      $query,
+      $optionValueValues
+    );
+    $valueField = $alias . '.value';
+
+    // Index by value
+    foreach ($optionValues as $key => $subResult) {
+      $optionValues[$subResult['value']] = $subResult;
+      unset($subResult[$key]);
+
+      // Exclude 'value' if not in original selects
+      if (!in_array($valueField, $selects)) {
+        unset($optionValues[$subResult['value']]['value']);
+      }
+    }
+
+    // Replace serialized with the sub-select results
+    foreach ($newResults as &$result) {
+      $result = array_merge($result, $optionValues[$result['value']]);
+      unset($result['value']);
+    }
+
+    return $newResults;
+  }
+
+
+  /**
+   * Prepares selects for the subquery to fetch join results
+   *
+   * @param string $alias
+   * @param array $selects
+   * @param Api4SelectQuery $query
+   *
+   * @return array
+   */
+  private function formatSelects($alias, $selects, Api4SelectQuery $query) {
+    $mainAlias = $query::MAIN_TABLE_ALIAS;
+    $selectFields = [];
+
+    foreach ($selects as $select) {
+      $selectAlias = $query->getFkSelectAliases()[$select];
+      $fieldAlias = substr($select, strrpos($select, '.') + 1);
+      $selectFields[$fieldAlias] = $selectAlias;
+    }
+
+    $firstSelect = $selects[0];
+    $pathParts = explode('.', $firstSelect);
+    $numParts = count($pathParts);
+    $parentAlias = $numParts > 2 ? $pathParts[$numParts - 3] : $mainAlias;
+
+    $selectFields['id'] = sprintf('%s.id', $alias);
+    $selectFields['_parent_id'] = $parentAlias . '.id';
+    $selectFields['_base_id'] = $mainAlias . '.id';
+
+    return $selectFields;
+  }
+
+  /**
+   * @param array $selects
+   * @param Api4SelectQuery $query
+   *
+   * @return array
+   */
+  private function runWithNewSelects(array $selects, Api4SelectQuery $query) {
+    $aliasedSelects = array_map(function ($field, $alias) {
+      return sprintf('%s as "%s"', $field, $alias);
+    }, $selects, array_keys($selects));
+
+    $newSelect = sprintf('SELECT DISTINCT %s', implode(", ", $aliasedSelects));
+    $sql = str_replace("\n", ' ', $query->getQuery()->toSQL());
+    $originalSelect = substr($sql, 0, strpos($sql, ' FROM'));
+    $sql = str_replace($originalSelect, $newSelect, $sql);
+
+    $relatedResults = [];
+    $resultDAO = \CRM_Core_DAO::executeQuery($sql);
+    while ($resultDAO->fetch()) {
+      $relatedResult = [];
+      foreach ($selects as $alias => $column) {
+        $returnName = $alias;
+        $alias = str_replace('.', '_', $alias);
+        if (property_exists($resultDAO, $alias)) {
+          $relatedResult[$returnName] = $resultDAO->$alias;
+        }
+      };
+      $relatedResults[] = $relatedResult;
+    }
+
+    return $relatedResults;
+  }
+
+  /**
+   * @param Api4SelectQuery $query
+   * @param $alias
+   * @param $selects
+   * @return array
+   */
+  protected function getJoinResults(Api4SelectQuery $query, $alias, $selects) {
+    $apiFieldSpec = $query->getApiFieldSpec();
+    if (!empty($apiFieldSpec[$alias]['serialize'])) {
+      $type = $apiFieldSpec[$alias]['serialize'];
+      $joinResults = $this->getResultsForSerializedField($selects, $type, $query);
+    }
+    else {
+      $joinResults = $this->runWithNewSelects($selects, $query);
+    }
+
+    // Remove results with no matching entries
+    $joinResults = array_filter($joinResults, function ($result) {
+      return !empty($result['id']);
+    });
+
+    return $joinResults;
+  }
+
+  /**
+   * Separates a string like 'emails.location_type.label' into an array, where
+   * each value in the array tells whether it is 1-1 or 1-n join type
+   *
+   * @param string $pathString
+   *   Dot separated path to the field
+   * @param Api4SelectQuery $query
+   *
+   * @return array
+   *   Index is table alias and value is boolean whether is 1-to-many join
+   */
+  private function getJoinPathInfo($pathString, $query) {
+    $pathParts = explode('.', $pathString);
+    array_pop($pathParts); // remove field
+    $path = [];
+    $isMultipleChecker = function($alias) use ($query) {
+      foreach ($query->getJoinedTables() as $table) {
+        if ($table->getAlias() === $alias) {
+          return $table->getJoinType() === Joinable::JOIN_TYPE_ONE_TO_MANY;
+        }
+      }
+      return FALSE;
+    };
+
+    foreach ($pathParts as $part) {
+      $path[$part] = $isMultipleChecker($part);
+    }
+
+    return $path;
+  }
+
+  /**
+   * Get all the option_value values required in the query
+   *
+   * @param array $selects
+   * @param Api4SelectQuery $query
+   * @param array $values
+   *
+   * @return array
+   */
+  private function getOptionValuesFromValues(
+    array $selects,
+    Api4SelectQuery $query,
+    array $values
+  ) {
+    $sampleField = current($selects);
+    $alias = strstr($sampleField, '.', TRUE);
+
+    // Get the option value table that was joined
+    $relatedTable = NULL;
+    foreach ($query->getJoinedTables() as $joinedTable) {
+      if ($joinedTable->getAlias() === $alias) {
+        $relatedTable = $joinedTable;
+      }
+    }
+
+    // We only want subselects related to the joined table
+    $subSelects = array_filter($selects, function ($select) use ($alias) {
+      return strpos($select, $alias) === 0;
+    });
+
+    // Fetch all related option_value entries
+    $valueField = $alias . '.value';
+    $subSelects[] = $valueField;
+    $tableName = $relatedTable->getTargetTable();
+    $conditions = $relatedTable->getExtraJoinConditions();
+    $conditions[] = $valueField . ' IN ("' . implode('", "', $values) . '")';
+    $subQuery = new \CRM_Utils_SQL_Select($tableName . ' ' . $alias);
+    $subQuery->where($conditions);
+    $subQuery->select($subSelects);
+    $subResults = $subQuery->execute()->fetchAll();
+
+    return $subResults;
+  }
+
+}

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -28,7 +28,8 @@
 namespace Civi\Api4\Query;
 
 use Civi\API\SelectQuery;
-use Civi\Api4\Utils\ArrayInsertionUtil;
+use Civi\Api4\Event\Events;
+use Civi\Api4\Event\PostSelectQueryEvent;
 use Civi\Api4\Service\Schema\Joinable\CustomGroupJoinable;
 use Civi\Api4\Service\Schema\Joinable\Joinable;
 use CRM_Core_DAO_AllCoreTables as TableHelper;
@@ -74,7 +75,10 @@ class Api4SelectQuery extends SelectQuery {
   public function run() {
     $this->preRun();
     $baseResults = parent::run();
-    return $this->postRun($baseResults);
+    $event = new PostSelectQueryEvent($baseResults, $this);
+    \Civi::dispatcher()->dispatch(Events::POST_SELECT_QUERY, $event);
+
+    return $event->getResults();
   }
 
   /**
@@ -89,75 +93,6 @@ class Api4SelectQuery extends SelectQuery {
 
     foreach ($dotFields as $dotField) {
       $this->joinFK($dotField);
-    }
-  }
-
-  /**
-   * @param $primaryResults
-   *
-   * @return array
-   */
-  protected function postRun($primaryResults) {
-    if (empty($primaryResults)) {
-      return $primaryResults;
-    }
-
-    $this->formatResults($primaryResults, $this->entity);
-
-    // Group the selects to avoid queries for each field
-    $groupedSelects = $this->getJoinedDotSelects();
-    foreach ($groupedSelects as $finalAlias => $selects) {
-      $path = $this->buildPath($selects[0]);
-      $selects = $this->formatSelects($finalAlias, $selects);
-
-      if (!empty($this->apiFieldSpec[$finalAlias]['serialize'])) {
-        $type = $this->apiFieldSpec[$finalAlias]['serialize'];
-        $joinResults = $this->getResultsForSerializedField($selects, $type);
-      } else {
-        $joinResults = $this->runWithNewSelects($selects);
-      }
-
-      // Remove results with no matching entries
-      $joinResults = array_filter($joinResults, function ($result) {
-        return !empty($result['id']);
-      });
-
-      // todo: call formatResults to unserialize joinResults
-      foreach ($primaryResults as &$primaryResult) {
-        $baseId = $primaryResult['id'];
-        $filtered = array_filter($joinResults, function ($res) use ($baseId) {
-          return ($res['_base_id'] === $baseId);
-        });
-        $filtered = array_values($filtered);
-        ArrayInsertionUtil::insert($primaryResult, $path, $filtered);
-      }
-    }
-
-    // no associative option
-    return array_values($primaryResults);
-  }
-
-  /**
-   * Unserialize values
-   *
-   * @param $results
-   * @param $entity
-   * @throws \API_Exception
-   */
-  protected function formatResults(&$results, $entity) {
-    if ($entity == $this->entity) {
-      $fields = $this->apiFieldSpec;
-    }
-    else {
-      $fields = civicrm_api4($entity, 'getFields', ['action' => 'get', 'includeCustom' => FALSE])->indexBy('name');
-    }
-    // Unserialize arrays
-    foreach ($results as &$result) {
-      foreach ($result as $field => &$value) {
-        if (!empty($fields[$field]['serialize']) && is_string($value)) {
-          $value = \CRM_Core_DAO::unSerializeField($value, $fields[$field]['serialize']);
-        }
-      }
     }
   }
 
@@ -333,147 +268,123 @@ class Api4SelectQuery extends SelectQuery {
     return TableHelper::getTableForClass(TableHelper::getFullName($this->entity));
   }
 
-
   /**
-   * @param string $pathString
-   *   Dot separated path to the field, e.g. emails.location_type.label
-   *
-   * @return array
-   *   Index is table alias and value is boolean whether is 1-to-many join
+   * @return string
    */
-  private function buildPath($pathString) {
-    $pathParts = explode('.', $pathString);
-    array_pop($pathParts); // remove field
-    $path = [];
-    $isMultipleChecker = function($alias)  {
-      foreach ($this->joinedTables as $table) {
-        if ($table->getAlias() === $alias) {
-          return $table->getJoinType() === Joinable::JOIN_TYPE_ONE_TO_MANY;
-        }
-      }
-      return FALSE;
-    };
-
-    foreach ($pathParts as $part) {
-      $path[$part] = $isMultipleChecker($part);
-    }
-
-    return $path;
-  }
-
-  /**
-   * @param $finalAlias
-   * @param $selects
-   *
-   * @return array
-   */
-  private function formatSelects($finalAlias, $selects) {
-    $mainAlias = self::MAIN_TABLE_ALIAS;
-    $selectFields = [];
-
-    foreach ($selects as $select) {
-      $selectAlias = $this->fkSelectAliases[$select];
-      $fieldAlias = substr($select, strrpos($select, '.') + 1);
-      $selectFields[$fieldAlias] = $selectAlias;
-    }
-
-    $firstSelect = $selects[0];
-    $pathParts = explode('.', $firstSelect);
-    $numParts = count($pathParts);
-    $parentAlias = $numParts > 2 ? $pathParts[$numParts - 3] : $mainAlias;
-
-    $selectFields['id'] = sprintf('%s.id', $finalAlias);
-    $selectFields['_parent_id'] = $parentAlias . '.id';
-    $selectFields['_base_id'] = $mainAlias . '.id';
-
-    return $selectFields;
-  }
-
-  /**
-   * @param array $selects
-   *
-   * @return array
-   */
-  private function runWithNewSelects(array $selects) {
-    $aliasedSelects = array_map(function ($field, $alias) {
-      return sprintf('%s as "%s"', $field, $alias);
-    }, $selects, array_keys($selects));
-
-    $newSelect = sprintf('SELECT DISTINCT %s', implode(", ", $aliasedSelects));
-    $sql = str_replace("\n", ' ', $this->query->toSQL());
-    $originalSelect = substr($sql, 0, strpos($sql, ' FROM'));
-    $sql = str_replace($originalSelect, $newSelect, $sql);
-
-    $relatedResults = [];
-    $resultDAO = \CRM_Core_DAO::executeQuery($sql);
-    while ($resultDAO->fetch()) {
-      $relatedResult = [];
-      foreach ($selects as $alias => $column) {
-        $returnName = $alias;
-        $alias = str_replace('.', '_', $alias);
-        if (property_exists($resultDAO, $alias)) {
-          $relatedResult[$returnName] = $resultDAO->$alias;
-        }
-      };
-      $relatedResults[] = $relatedResult;
-    }
-
-    return $relatedResults;
+  public function getEntity() {
+    return $this->entity;
   }
 
   /**
    * @return array
    */
-  private function getJoinedDotSelects() {
-    $joinedDotSelects = array_filter($this->select, function ($select) {
-      return isset($this->fkSelectAliases[$select]);
-    });
-
-    $selects = [];
-    // group related selects by alias so they can be executed in one query
-    foreach ($joinedDotSelects as $select) {
-      $parts = explode('.', $select);
-      $finalAlias = $parts[count($parts) - 2];
-      $selects[$finalAlias][] = $select;
-    }
-
-    // sort by depth, e.g. email selects should be done before email.location
-    uasort($selects, function ($a, $b) {
-      $aFirst = $a[0];
-      $bFirst = $b[0];
-      return substr_count($aFirst, '.') > substr_count($bFirst, '.');
-    });
-
-    return $selects;
+  public function getSelect() {
+    return $this->select;
   }
 
   /**
-   * @param array $selects
-   * @param string $serializationType
-   *
    * @return array
    */
-  private function getResultsForSerializedField(array $selects, $serializationType) {
-    $sampleField = current($selects);
-    $alias = strstr($sampleField, '.', TRUE);
-    $results = $this->runWithNewSelects([
-      'serialized' => self::MAIN_TABLE_ALIAS . '.' . $alias,
-      '_parent_id' => $selects['_parent_id'],
-      '_base_id' => $selects['_base_id'],
-    ]);
+  public function getWhere() {
+    return $this->where;
+  }
 
-    foreach($results as $result) {
-      $unserialized = \CRM_Core_DAO::unSerializeField(
-        $result['serialized'],
-        $serializationType
-      );
-      $unserializedResults[$result['_parent_id']] = $unserialized;
-    }
+  /**
+   * @return array
+   */
+  public function getOrderBy() {
+    return $this->orderBy;
+  }
 
-    // todo do a new query to the option_value table for all values in $unserializedResults
-    // then loop through all $results and replace serialized with the resulting array
+  /**
+   * @return mixed
+   */
+  public function getLimit() {
+    return $this->limit;
+  }
 
-    return [];
+  /**
+   * @return mixed
+   */
+  public function getOffset() {
+    return $this->offset;
+  }
+
+  /**
+   * @return array
+   */
+  public function getSelectFields() {
+    return $this->selectFields;
+  }
+
+  /**
+   * @return bool
+   */
+  public function isFillUniqueFields() {
+    return $this->isFillUniqueFields;
+  }
+
+  /**
+   * @return \CRM_Utils_SQL_Select
+   */
+  public function getQuery() {
+    return $this->query;
+  }
+
+  /**
+   * @return array
+   */
+  public function getJoins() {
+    return $this->joins;
+  }
+
+  /**
+   * @return array
+   */
+  public function getApiFieldSpec() {
+    return $this->apiFieldSpec;
+  }
+
+  /**
+   * @return array
+   */
+  public function getEntityFieldNames() {
+    return $this->entityFieldNames;
+  }
+
+  /**
+   * @return array
+   */
+  public function getAclFields() {
+    return $this->aclFields;
+  }
+
+  /**
+   * @return bool|string
+   */
+  public function getCheckPermissions() {
+    return $this->checkPermissions;
+  }
+
+  /**
+   * @return int
+   */
+  public function getApiVersion() {
+    return $this->apiVersion;
+  }
+
+  /**
+   * @return array
+   */
+  public function getFkSelectAliases() {
+    return $this->fkSelectAliases;
+  }
+
+  /**
+   * @return Joinable[]
+   */
+  public function getJoinedTables() {
+    return $this->joinedTables;
   }
 
 }

--- a/Civi/Api4/Service/Schema/Joinable/Joinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/Joinable.php
@@ -160,6 +160,14 @@ class Joinable {
 
     return $this;
   }
+
+  /**
+   * @return array
+   */
+  public function getExtraJoinConditions() {
+    return $this->conditions;
+  }
+
   /**
    * @param array $conditions
    *

--- a/Civi/Api4/Service/Schema/Joinable/Joinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/Joinable.php
@@ -216,6 +216,26 @@ class Joinable {
   }
 
   /**
+   * @param string $targetTable
+   * @return $this
+   */
+  public function setTargetTable($targetTable) {
+    $this->targetTable = $targetTable;
+
+    return $this;
+  }
+
+  /**
+   * @param string $targetColumn
+   * @return $this
+   */
+  public function setTargetColumn($targetColumn) {
+    $this->targetColumn = $targetColumn;
+
+    return $this;
+  }
+
+  /**
    * @return array
    */
   public function toArray() {

--- a/Civi/Api4/Service/Schema/Joinable/OptionValueJoinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/OptionValueJoinable.php
@@ -39,4 +39,23 @@ class OptionValueJoinable extends Joinable {
     $this->addCondition($condition);
   }
 
+  /**
+   * The existing condition must also be re-aliased
+   *
+   * @param string $alias
+   *
+   * @return $this
+   */
+  public function setAlias($alias) {
+    foreach ($this->conditions as $index => $condition) {
+      $search = $this->alias . '.';
+      $replace = $alias . '.';
+      $this->conditions[$index] = str_replace($search, $replace, $condition);
+    }
+
+    parent::setAlias($alias);
+
+    return $this;
+  }
+
 }

--- a/Civi/Api4/Service/Schema/Joiner.php
+++ b/Civi/Api4/Service/Schema/Joiner.php
@@ -71,7 +71,8 @@ class Joiner {
    * @throws \Exception
    */
   protected function getPath($baseTable, $joinPath) {
-    if (!isset($this->cache[$joinPath])) {
+    $cacheKey = sprintf('%s.%s', $baseTable, $joinPath);
+    if (!isset($this->cache[$cacheKey])) {
       $stack = explode('.', $joinPath);
       $fullPath = [];
 
@@ -88,10 +89,10 @@ class Joiner {
         }
       }
 
-      $this->cache[$joinPath] = $fullPath;
+      $this->cache[$cacheKey] = $fullPath;
     }
 
-    return $this->cache[$joinPath];
+    return $this->cache[$cacheKey];
   }
 
 }

--- a/Civi/Api4/Service/Schema/SchemaMapBuilder.php
+++ b/Civi/Api4/Service/Schema/SchemaMapBuilder.php
@@ -99,7 +99,8 @@ class SchemaMapBuilder {
       $table->addTableLink($field, $joinable);
     }
     elseif ($optionGroupName) {
-      $joinable = new OptionValueJoinable($optionGroupName);
+      $keyColumn = ArrayHelper::value('keyColumn', $pseudoConstant, 'value');
+      $joinable = new OptionValueJoinable($optionGroupName, NULL, $keyColumn);
 
       if (!empty($data['serialize'])) {
         $joinable->setJoinType($joinable::JOIN_TYPE_ONE_TO_MANY);

--- a/Civi/Api4/Service/Schema/SchemaMapBuilder.php
+++ b/Civi/Api4/Service/Schema/SchemaMapBuilder.php
@@ -63,7 +63,6 @@ class SchemaMapBuilder {
    * @param array $data
    */
   private function addJoins(Table $table, $field, array $data) {
-    $pseudoConstant = ArrayHelper::value('pseudoconstant', $data);
     $fkClass = ArrayHelper::value('FKClassName', $data);
 
     // can there be multiple methods e.g. pseudoconstant and fkclass
@@ -74,8 +73,8 @@ class SchemaMapBuilder {
       $joinable->setJoinType($joinable::JOIN_TYPE_MANY_TO_ONE);
       $table->addTableLink($field, $joinable);
     }
-    elseif ($pseudoConstant) {
-      $this->addPseudoConstantJoin($table, $field, $pseudoConstant);
+    elseif (ArrayHelper::value('pseudoconstant', $data)) {
+      $this->addPseudoConstantJoin($table, $field, $data);
     }
   }
 
@@ -85,14 +84,15 @@ class SchemaMapBuilder {
    * @param array $data
    */
   private function addPseudoConstantJoin(Table $table, $field, array $data) {
-    $tableName = ArrayHelper::value('table', $data);
-    $optionGroupName = ArrayHelper::value('optionGroupName', $data);
-    $keyColumn = ArrayHelper::value('keyColumn', $data, 'id');
+    $pseudoConstant = ArrayHelper::value('pseudoconstant', $data);
+    $tableName = ArrayHelper::value('table', $pseudoConstant);
+    $optionGroupName = ArrayHelper::value('optionGroupName', $pseudoConstant);
+    $keyColumn = ArrayHelper::value('keyColumn', $pseudoConstant, 'id');
 
     if ($tableName) {
       $alias = str_replace('civicrm_', '', $tableName);
       $joinable = new Joinable($tableName, $keyColumn, $alias);
-      $condition = ArrayHelper::value('condition', $data);
+      $condition = ArrayHelper::value('condition', $pseudoConstant);
       if ($condition) {
         $joinable->addCondition($condition);
       }
@@ -100,6 +100,11 @@ class SchemaMapBuilder {
     }
     elseif ($optionGroupName) {
       $joinable = new OptionValueJoinable($optionGroupName);
+
+      if (!empty($data['serialize'])) {
+        $joinable->setJoinType($joinable::JOIN_TYPE_ONE_TO_MANY);
+      }
+
       $table->addTableLink($field, $joinable);
     }
   }

--- a/Civi/Api4/Service/Schema/Table.php
+++ b/Civi/Api4/Service/Schema/Table.php
@@ -60,6 +60,17 @@ class Table {
   }
 
   /**
+   * @param Joinable $linkToRemove
+   */
+  public function removeLink(Joinable $linkToRemove) {
+    foreach ($this->tableLinks as $index => $link) {
+      if ($link === $linkToRemove) {
+        unset($this->tableLinks[$index]);
+      }
+    }
+  }
+
+  /**
    * @param string $baseColumn
    * @param Joinable $joinable
    *

--- a/services.xml
+++ b/services.xml
@@ -77,5 +77,9 @@
             <tag name="event_subscriber"/>
         </service>
 
+        <service id="api4.post_select_query.subscriber" class="Civi\Api4\Event\Subscriber\PostSelectQuerySubscriber">
+            <tag name="event_subscriber"/>
+        </service>
+
     </services>
 </container>

--- a/tests/phpunit/DataSets/MultiContactMultiEmail.json
+++ b/tests/phpunit/DataSets/MultiContactMultiEmail.json
@@ -1,0 +1,42 @@
+{
+  "Contact": [
+    {
+      "first_name": "First",
+      "last_name": "Contact",
+      "contact_type": "Individual",
+      "@ref": "test_contact_1"
+    },
+    {
+      "first_name": "Second",
+      "last_name": "Contact",
+      "contact_type": "Individual",
+      "@ref": "test_contact_2"
+    }
+  ],
+  "Email": [
+    {
+      "contact_id": "@ref test_contact_1.id",
+      "email": "test_contact_one_home@fakedomain.com",
+      "location_type_id": 1,
+      "@ref": "test_email_1"
+    },
+    {
+      "contact_id": "@ref test_contact_1.id",
+      "email": "test_contact_one_work@fakedomain.com",
+      "location_type_id": 2,
+      "@ref": "test_email_2"
+    },
+    {
+      "contact_id": "@ref test_contact_2.id",
+      "email": "test_contact_two_home@fakedomain.com",
+      "location_type_id": 1,
+      "@ref": "test_email_3"
+    },
+    {
+      "contact_id": "@ref test_contact_2.id",
+      "email": "test_contact_two_work@fakedomain.com",
+      "location_type_id": 2,
+      "@ref": "test_email_4"
+    }
+  ]
+}

--- a/tests/phpunit/DataSets/SingleContact.json
+++ b/tests/phpunit/DataSets/SingleContact.json
@@ -46,6 +46,11 @@
       "name": "Phone",
       "value": "phone",
       "option_group": "preferred_communication_method"
+    },
+    {
+      "name": "Email",
+      "value": "email",
+      "option_group": "preferred_communication_method"
     }
   ],
   "Activity": [

--- a/tests/phpunit/Entity/ConformanceTest.php
+++ b/tests/phpunit/Entity/ConformanceTest.php
@@ -34,6 +34,8 @@ class ConformanceTest extends UnitTestCase {
     $this->loadDataSet('ConformanceTest');
     $this->creationParamProvider = \Civi::container()->get('test.param_provider');
     parent::setUp();
+    // calculateTaxAmount() for contribution triggers a deprecation notice
+    \PHPUnit_Framework_Error_Deprecated::$enabled = FALSE;
   }
 
   public function testConformance() {

--- a/tests/phpunit/Entity/ContactJoinTest.php
+++ b/tests/phpunit/Entity/ContactJoinTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace phpunit\Entity;
+namespace Civi\Test\Api4\Entity;
 
 use Civi\Api4\Entity\Contact;
 use Civi\Test\Api4\UnitTestCase;

--- a/tests/phpunit/Entity/ContactJoinTest.php
+++ b/tests/phpunit/Entity/ContactJoinTest.php
@@ -78,10 +78,18 @@ class ContactJoinTest extends UnitTestCase {
       'preferred_communication_method' => $optionValues,
       'contact_type' => 'Individual',
       'first_name' => 'Test', 'last_name' => 'PCM'
-    ])->execute();
+    ])->execute()->getArrayCopy();
+
+    $contact2 = Contact::create()->setValues([
+      'preferred_communication_method' => $optionValues,
+      'contact_type' => 'Individual',
+      'first_name' => 'Test', 'last_name' => 'PCM2'
+    ])->execute()->getArrayCopy();
+
+    $contactIds = array_column([$contact, $contact2], 'id');
 
     $fetchedContact = Contact::get()
-      ->addWhere('id', '=', $contact['id'])
+      ->addWhere('id', 'IN', $contactIds)
       ->addSelect('preferred_communication_method.label')
       ->execute()
       ->first();

--- a/tests/phpunit/Entity/ContactJoinTest.php
+++ b/tests/phpunit/Entity/ContactJoinTest.php
@@ -95,8 +95,9 @@ class ContactJoinTest extends UnitTestCase {
       ->first();
 
     $preferredMethod = $fetchedContact['preferred_communication_method'];
+    $returnedLabels = array_column($preferredMethod, 'label');
 
-    $this->assertEquals($labels, $preferredMethod);
+    $this->assertEquals($labels, $returnedLabels);
   }
 
 }

--- a/tests/phpunit/Entity/ContactJoinTest.php
+++ b/tests/phpunit/Entity/ContactJoinTest.php
@@ -32,8 +32,11 @@ class ContactJoinTest extends UnitTestCase {
   }
 
   public function testContactJoin() {
+
     $contact = $this->getReference('test_contact_1');
-    foreach (['Address', 'Email', 'Phone', 'OpenID', 'IM', 'Website'] as $entity) {
+    $entitiesToTest = ['Address', 'OpenID', 'IM', 'Website', 'Email', 'Phone'];
+
+    foreach ($entitiesToTest as $entity) {
       $results = civicrm_api4($entity, 'get', [
         'where' => [['contact_id', '=', $contact['id']]],
         'select' => ['contact.display_name', 'contact.id'],

--- a/tests/phpunit/Query/Api4SelectQueryTest.php
+++ b/tests/phpunit/Query/Api4SelectQueryTest.php
@@ -86,4 +86,24 @@ class Api4SelectQueryTest extends UnitTestCase {
     $this->assertEquals($contact['display_name'], $resultContact['display_name']);
   }
 
+  public function testOneToManyMultipleJoin() {
+    $query = new Api4SelectQuery('Contact', FALSE);
+    $query->select[] = 'id';
+    $query->select[] = 'first_name';
+    $query->select[] = 'phones.phone';
+    $results = $query->run();
+
+    $this->assertCount(2, $results);
+
+    foreach ($results as $result) {
+      if ($result['id'] == 2) {
+        // Contact has no phones
+        $this->assertEmpty($result['phones']);
+      }
+      elseif ($result['id'] == 1) {
+        $this->assertCount(2, $result['phones']);
+      }
+    }
+  }
+
 }

--- a/tests/phpunit/Query/OneToOneJoinTest.php
+++ b/tests/phpunit/Query/OneToOneJoinTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Civi\Test\Api4\Query;
+
+use Civi\Api4\Entity\Contact;
+use Civi\Api4\Entity\OptionGroup;
+use Civi\Api4\Entity\OptionValue;
+use Civi\Test\Api4\UnitTestCase;
+
+class OneToOneJoinTest extends UnitTestCase {
+
+  public function testOneToOneJoin() {
+    $languageGroupId = OptionGroup::create()
+      ->setValue('name', 'languages')
+      ->execute()
+      ->getArrayCopy()['id'];
+
+    OptionValue::create()
+      ->setValue('option_group_id', $languageGroupId)
+      ->setValue('name', 'hy_AM')
+      ->setValue('value', 'hy')
+      ->setValue('label', 'Armenian')
+      ->execute();
+
+    OptionValue::create()
+      ->setValue('option_group_id', $languageGroupId)
+      ->setValue('name', 'eu_ES')
+      ->setValue('value', 'eu')
+      ->setValue('label', 'Basque')
+      ->execute();
+
+    $armenianContact = Contact::create()
+      ->setValue('first_name', 'Contact')
+      ->setValue('last_name', 'One')
+      ->setValue('contact_type', 'Individual')
+      ->setValue('preferred_language', 'hy_AM')
+      ->execute()
+      ->getArrayCopy();
+
+    $basqueContact = Contact::create()
+      ->setValue('first_name', 'Contact')
+      ->setValue('last_name', 'Two')
+      ->setValue('contact_type', 'Individual')
+      ->setValue('preferred_language', 'eu_ES')
+      ->execute()
+      ->getArrayCopy();
+
+    $contacts = Contact::get()
+      ->addWhere('id', 'IN', [$armenianContact['id'], $basqueContact['id']])
+      ->addSelect('preferred_language.label')
+      ->addSelect('last_name')
+      ->execute()
+      ->indexBy('last_name')
+      ->getArrayCopy();
+
+    $this->assertEquals($contacts['One']['preferred_language']['label'], 'Armenian');
+    $this->assertEquals($contacts['Two']['preferred_language']['label'], 'Basque');
+  }
+
+}

--- a/tests/phpunit/Query/OptionValueJoinTest.php
+++ b/tests/phpunit/Query/OptionValueJoinTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace phpunit\Query;
+namespace Civi\Test\Api4\Query;
 
 use Civi\Api4\Query\Api4SelectQuery;
 use Civi\Test\Api4\UnitTestCase;

--- a/tests/phpunit/Query/OptionValueJoinTest.php
+++ b/tests/phpunit/Query/OptionValueJoinTest.php
@@ -36,10 +36,12 @@ class OptionValueJoinTest extends UnitTestCase {
     $query->select[] = 'first_name';
     $query->select[] = 'preferred_communication_method.label';
     $results = $query->run();
+    $first = array_shift($results);
+    $firstPreferredMethod = array_shift($first['preferred_communication_method']);
 
     $this->assertEquals(
       'Phone',
-      $results[0]['preferred_communication_method']['label']
+      $firstPreferredMethod['label']
     );
   }
 

--- a/tests/phpunit/Query/SelectQueryMultiJoinTest.php
+++ b/tests/phpunit/Query/SelectQueryMultiJoinTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Civi\Test\Api4\Query;
+
+use Civi\Api4\Entity\Contact;
+use Civi\Api4\Entity\Email;
+use Civi\Test\Api4\UnitTestCase;
+
+class SelectQueryMultiJoinTest extends UnitTestCase {
+  public function setUpHeadless() {
+    $this->cleanup(['tablesToTruncate' => ['civicrm_contact', 'civicrm_email']]);
+    $this->loadDataSet('MultiContactMultiEmail');
+    return parent::setUpHeadless();
+  }
+
+  public function testOneToManySelect() {
+    $results = Contact::get()
+      ->addSelect('emails.email')
+      ->execute()
+      ->indexBy('id')
+      ->getArrayCopy();
+
+    $firstContactId = $this->getReference('test_contact_1')['id'];
+    $secondContactId = $this->getReference('test_contact_2')['id'];
+
+    $firstContact = $results[$firstContactId];
+    $secondContact = $results[$secondContactId];
+    $firstContactEmails = array_column($firstContact['emails'], 'email');
+    $secondContactEmails = array_column($secondContact['emails'], 'email');
+
+    $expectedFirstEmails = [
+    'test_contact_one_home@fakedomain.com',
+    'test_contact_one_work@fakedomain.com',
+    ];
+    $expectedSecondEmails = [
+      'test_contact_two_home@fakedomain.com',
+      'test_contact_two_work@fakedomain.com',
+    ];
+
+    $this->assertEquals($expectedFirstEmails, $firstContactEmails);
+    $this->assertEquals($expectedSecondEmails, $secondContactEmails);
+  }
+
+  public function testManyToOneSelect() {
+    $results = Email::get()
+      ->addSelect('contact.display_name')
+      ->execute()
+      ->indexBy('id')
+      ->getArrayCopy();
+
+    $firstEmail = $this->getReference('test_email_1');
+    $secondEmail = $this->getReference('test_email_2');
+    $thirdEmail = $this->getReference('test_email_3');
+    $fourthEmail = $this->getReference('test_email_4');
+    $firstContactEmailIds = [$firstEmail['id'], $secondEmail['id']];
+    $secondContactEmailIds = [$thirdEmail['id'], $fourthEmail['id']];
+
+    foreach ($results as $id => $email) {
+      $displayName = $email['contact']['display_name'];
+      if (in_array($id, $firstContactEmailIds)) {
+        $this->assertEquals('First Contact', $displayName);
+      }
+      elseif (in_array($id, $secondContactEmailIds)) {
+        $this->assertEquals('Second Contact', $displayName);
+      }
+    }
+  }
+
+}

--- a/tests/phpunit/Service/Schema/SchemaMapRealTableTest.php
+++ b/tests/phpunit/Service/Schema/SchemaMapRealTableTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace phpunit\Civi\API\Service\Schema;
+namespace Civi\Test\Api4\Service\Schema;
 
 use Civi\Test\Api4\UnitTestCase;
 

--- a/tests/phpunit/Service/Schema/SchemaMapperTest.php
+++ b/tests/phpunit/Service/Schema/SchemaMapperTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace phpunit\Civi\API\Service\Schema;
+namespace Civi\Test\Api4\Service\Schema;
 
 use Civi\Api4\Service\Schema\Joinable\Joinable;
 use Civi\Api4\Service\Schema\SchemaMap;


### PR DESCRIPTION
## Before

When selecting the reverse of 1-to-n entity some results would not be returned.

## After 

All nested results from n-to-1 joins are returned.

## Technical Details

The problem was in `Api4SelectQuery::runWithNewSelects`. Consider you have a contact (ID 1) which has two emails (IDs 1 & 2).

The `runWithNewSelects` call is done in query post processing. If we select email and also request joined data from the related contact, such as `contact.display_name` then this method will fetch the related results. 

In our example we first select the emails 1 & 2. In post processing we will fetch the related contact, which will return contact 1. The query will be something like:

```
SELECT DISTINCT contact.display_name as "display_name", contact.id as "id", a.id as "_parent_id"
FROM civicrm_email a 
LEFT JOIN `civicrm_contact` `contact` ON a.contact_id =  contact.id 
WHERE (`a`.`contact_id` = "1") 
```

Now we loop through these and return the results. The problem was that the results were being indexed by `$resultDAO->id`, which is the contact ID. 

So instead of returning the two contacts (one for each email result) we return a single contact, which only matches the second email (ID 2).

The solution in this PR is to use a sequential index for the related results, since the index is not used elsewhere anyway.

During the course of investigation I found that for 1-to-n selects it was possible for empty nested entities to be returned, so I added a filter for this.