### PR TITLE
Update specFormatter to read serialization from core

### DIFF
--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -39,9 +39,7 @@ class SpecFormatter {
       $field->setCustomGroupId($data['custom_group_id']);
       $field->setRequired((bool) ArrayHelper::value('is_required', $data, FALSE));
       $field->setTitle(ArrayHelper::value('label', $data));
-      if (\CRM_Core_BAO_CustomField::isSerialized($data)) {
-        $field->setSerialize(\CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND);
-      }
+      $field->setSerialize(\CRM_Core_BAO_CustomField::isSerialized($data));
     }
     else {
       $name = ArrayHelper::value('name', $data);


### PR DESCRIPTION
Depends on https://github.com/civicrm/civicrm-core/pull/11438
Merge after that PR makes it into a release of CiviCRM, as this improvement isn't important enough to force people to use an RC.